### PR TITLE
Ensure sent packets go via correct interface by setting IP_MULTICAST_IF

### DIFF
--- a/castaway.py
+++ b/castaway.py
@@ -4,10 +4,12 @@
 from scapy.all import *
 from struct import pack
 from time import sleep
+import scapy.arch
 import requests
 import xml.etree.ElementTree as ET
 import binascii
 import sys
+import socket
 
 ## Create a Packet Count var
 packetCount = 0
@@ -98,7 +100,9 @@ def spoof_response(pkt):
 
     #spoofed_pkt = IP(src='192.168.1.104', dst='224.0.0.251')/UDP(dport='mdns', sport='mdns')/Raw(load=data_hex)
     spoofed_pkt = IP(src=redirect_to, dst=pkt[IP].dst)/UDP(dport='mdns', sport='mdns')/Raw(load=data_hex)
-    send(spoofed_pkt)
+    sock=conf.L3socket()
+    sock.outs.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton(scapy.arch.get_if_addr(interface)))
+    send(spoofed_pkt,socket=sock)
     print 'Sent spoofed response:', spoofed_pkt.summary()
 
 


### PR DESCRIPTION
At least on my system (with scapy 2.4.3), the sent packets were going out of the wrong interface by default. In that version of scapy there didn't seem to be a way to force this (it seems to use separate sending and receiving sockets, and relying on routing table for choosing output interface for L3 packets), so I've had to mess with scapy internals a bit. Therefore possible it  won't work with newer versions.

I also didn't actually test these changes on python2, so possible PR #11 may need merging first.